### PR TITLE
Fixing Makefile, mount breakout module, and bug with parsing module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,19 @@
 # !!!MAKE SURE YOUR GOPATH ENVIRONMENT VARIABLE IS SET FIRST!!!
 
+# Quick start:
+# make
+# After it finish, it will created files in data/temp/<version>/<id>/
+# Then you can package it by running: "make package-agent-linux" or "make package-all"
 # Merlin Server & Agent version number
 VERSION=$(shell cat pkg/merlin.go |grep "const Version ="|cut -d"\"" -f2)
 
-MSERVER=merlinServer
-MAGENT=merlinAgent
-PASSWORD=merlin
+MSERVER=kubesploitServer
+MAGENT=kubesploitAgent
+PASSWORD=kubesploit
 BUILD=$(shell git rev-parse HEAD)
 DIR=data/temp/v${VERSION}/${BUILD}
 BIN=data/bin/
-XBUILD=-X main.build=${BUILD} -X github.com/Ne0nd0g/merlin/pkg/agent.build=${BUILD}
+XBUILD=-X main.build=${BUILD} -X github.com/cyberark/kubesploit/pkg/agent.build=${BUILD}
 URL ?= https://127.0.0.1:443
 XURL=-X main.url=${URL}
 PSK ?= merlin
@@ -27,9 +31,9 @@ WINAGENTLDFLAGS=-ldflags "-s -w ${XBUILD} ${XPROTO} ${XURL} ${XHOST} ${XPSK} ${X
 # TODO Update when Go1.13 is released https://stackoverflow.com/questions/45279385/remove-file-paths-from-text-directives-in-go-binaries
 GCFLAGS=-gcflags=all=-trimpath=$(GOPATH)
 ASMFLAGS=-asmflags=all=-trimpath=$(GOPATH)# -asmflags=-trimpath=$(GOPATH)
-PACKAGE=7za a -p${PASSWORD} -mhe -mx=9
-F=README.MD LICENSE data/modules docs data/README.MD data/agents/README.MD data/db/ data/log/README.MD data/x509 data/src data/bin data/html
-F2=LICENSE
+PACKAGE=7za a -p${PASSWORD} #-mhe -mx=9
+F=README.MD LICENSE NOTICES.txt config.yaml kubesploit.yara data/bin data/html data/modules
+F2=LICENSE NOTICES.txt
 W=Windows-x64
 L=Linux-x64
 A=Linux-arm
@@ -41,7 +45,8 @@ export GO111MODULE=on
 $(shell mkdir -p ${DIR})
 
 # Change default to just make for the host OS and add MAKE ALL to do this
-default: server-windows agent-windows server-linux agent-linux server-darwin agent-darwin agent-dll agent-javascript prism-windows prism-linux prism-darwin
+#default: server-windows agent-windows server-linux agent-linux server-darwin agent-darwin agent-dll agent-javascript prism-windows prism-linux prism-darwin
+default: server-linux agent-linux server-darwin agent-darwin agent-javascript prism-linux prism-darwin
 
 all: default
 
@@ -169,7 +174,8 @@ package-prism-darwin:
 	cp ${DIR}/PRISM-${D} ${BIN}darwin/
 
 # Package agents and PRISM first so that they can be included in the Server distro
-package-all: package-agent-windows package-agent-dll package-agent-linux package-agent-darwin package-prism-windows package-prism-linux package-prism-darwin package-server-linux package-server-windows package-server-darwin
+#package-all: package-agent-windows package-agent-dll package-agent-linux package-agent-darwin package-prism-windows package-prism-linux package-prism-darwin package-server-linux package-server-windows package-server-darwin
+package-all: package-agent-linux package-agent-darwin package-prism-linux package-prism-darwin package-server-linux package-server-darwin
 
 clean:
 	rm -rf ${DIR}*

--- a/README.MD
+++ b/README.MD
@@ -60,7 +60,7 @@ To run quick build for Linux, you can run the following:
 ```
 export PATH=$PATH:/usr/local/go/bin
 go build -o agent cmd/merlinagent/main.go
-go build -o agent cmd/merlinserver/main.go
+go build -o server cmd/merlinserver/main.go
 ```
 
 ## Mitigations 

--- a/data/modules/linux/go/mountContainerBreakout.json
+++ b/data/modules/linux/go/mountContainerBreakout.json
@@ -1,6 +1,6 @@
 {
   "base": {
-    "name": "Container Breakout via mounting",
+    "name": "ContainerBreakoutMounting",
     "type": "standard",
     "author": ["Eviatar Gerzi (@g3rzi)"],
     "credits": [],
@@ -15,13 +15,14 @@
     "remote": "",
     "local": [],
     "options": [
-      {"name": "Device", "value": "", "required": false, "flag": "", "description": "Use known device name (i.e \"/dev/sda1\", \"/dev/xvda1\")"},
-      {"name": "UseBruteforce", "value": "false", "required": false, "flag": "", "description": "Use the \"true\" value to use brute force on known devices: \"/dev/sda1\" and \"/dev/xvda1\")"}
+      {"name": "Device", "value": "none", "required": false, "flag": "", "description": "Use known device name (i.e \"/dev/sda1\", \"/dev/xvda1\")"},
+      {"name": "UseBruteforce", "value": "false", "required": false, "flag": "", "description": "Use the \"true\" value to use brute force on known devices: \"/dev/sda1\" and \"/dev/xvda1\")"},
+      {"name": "DeviceType", "value": "ext4", "required": false, "flag": "", "description": "Searching by device type. The default is \"ext4\", and to disable, set an empty string \"\"."}
     ],
     "description": "Break out from the container to the host using mounting. It will create a mounted host folder named /mnt<number>",
     "commands": [
       "data/modules/go/mountBreakout/main.go",
-      "mainfunc(\"{{Device}}\", \"{{UseBruteforce}}\")"
+      "mainfunc(\"{{Device}}\", \"{{UseBruteforce}}\", \"{{DeviceType}}\")"
     ]
   }
 }

--- a/pkg/merlin.go
+++ b/pkg/merlin.go
@@ -19,7 +19,7 @@
 package kubesploitVersion
 
 // Version is a constant variable containing the version number for Kubesploit
-const Version = "0.1.0"
+const Version = "0.1.1"
 
 // MerlinVersion is a constant variable containing the version number for the Merlin package
 const MerlinVersion = "0.9.1"

--- a/pkg/modules/modules.go
+++ b/pkg/modules/modules.go
@@ -129,7 +129,11 @@ func Run(m Module) ([]string, error) {
 			// Check if an option was set WITHOUT the Flag or Value qualifiers
 			if reName.MatchString(command[k]) {
 				if o.Value != "" {
-					command[k] = reName.ReplaceAllString(command[k], o.Flag+" "+o.Value)
+					flagSpace := ""
+					if o.Flag != "" {
+						flagSpace = " "
+					}
+					command[k] = reName.ReplaceAllString(command[k], o.Flag+flagSpace+o.Value)
 				} else {
 					command = append(command[:k], command[k+1:]...)
 				}


### PR DESCRIPTION
### Pull Request (PR) Checklist
- [x] I have read the [CONTRIBUTING](./CONTRIBUTING.MD) doc
- [ ] PR is from **a topic/feature/bugfix branch** off the **dev branch** (right side)
- [ ] PR is against the **dev branch** (left side)
- [ ] Merlin compiles without errors
- [ ] Passes linting checks and unit tests
- [ ] Updated [CHANGELOG](./CHANGELOG.MD)
- [ ] Updated README documentation (if applicable)
- [ ] Update Merlin version number in `pkg/merlin.go` (if applicable)

### Change Type
- [ ] Addition
- [x] Bugfix
- [x] Modification
- [ ] Removal
- [ ] Security

### Description

These are the changes:
- Fix bug with parsing module. When `Flag` variable is not set, it still add space to the argument of the Go module. 
- The breakout mount module didn't work well in a case of missing `UUID` in `/proc/cmd`, I added option to check by device type `ext4`.
- Makefile tried to compile for Windows and other issue with compressing, did some changes.

