### PR TITLE
Fix bug with marshling: "Failed to print unexpected end of JSON input"

### DIFF
--- a/data/modules/go/kubelet/main.go
+++ b/data/modules/go/kubelet/main.go
@@ -564,9 +564,12 @@ func PrintDecodedToken(tokenString string) {
 	sDec, _  := b64.StdEncoding.DecodeString(splittedToken[1])
 	newDec:= string(sDec)
 	newDec = strings.Replace(newDec, "\r\n", "\n", -1)
-
+	if !strings.HasSuffix(newDec, "}"){
+		newDec += "}"
+	}
+	
 	var jwtToken JWTToken
-	err := json.Unmarshal([]byte(sDec), &jwtToken)
+	err := json.Unmarshal([]byte(newDec), &jwtToken)
 	if err != nil {
 		fmt.Printf("[*] Failed to print %s", err)
 	} else {

--- a/pkg/merlin.go
+++ b/pkg/merlin.go
@@ -19,7 +19,7 @@
 package kubesploitVersion
 
 // Version is a constant variable containing the version number for Kubesploit
-const Version = "0.1.2"
+const Version = "0.1.3"
 
 // MerlinVersion is a constant variable containing the version number for the Merlin package
 const MerlinVersion = "0.9.1"


### PR DESCRIPTION
The `Unmarshal` function used wrong parameter `sDec` instead of the new one `newDec`.  
Second issue was that some tokens are being set with bad base64.  
For example:  
1234 in base64 is: "MTIzNA=="  
If you will remove the "==" in some places you will still get "1234" but in the Go function it remove the "4".
So using "MTIzNA" will result "123" instead of "1234".  
I noticed that some service account tokens have this issue. This is why I added "}" in case it is missing.


### Pull Request (PR) Checklist
- [x] I have read the [CONTRIBUTING](./CONTRIBUTING.MD) doc
- [ ] PR is from **a topic/feature/bugfix branch** off the **dev branch** (right side)
- [ ] PR is against the **dev branch** (left side)
- [ ] Kubesploit compiles without errors
- [ ] Passes linting checks and unit tests
- [ ] Updated [CHANGELOG](./CHANGELOG.MD)
- [ ] Updated README documentation (if applicable)
- [x] Update Kubesploit version number in `pkg/merlin.go` (if applicable)

### Change Type
- [ ] Addition
- [x] Bugfix
- [ ] Modification
- [ ] Removal
- [ ] Security

### Description
