### PR TITLE
adding golang version pre-reqs from traefik/yaegi

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -57,6 +57,8 @@ It’s a full simulation with a complete set of automated instructions on how to
 ## Build
 To build this project, run the `make` command from the root folder. 
 
+**NOTE:** Currently you'll need to use golang 1.13 or 1.14 based on the golang requirements that [traefik/yaegi v0.9.2](https://github.com/traefik/yaegi/tree/v0.9.2#features) have.
+
 ### Quick Build  
 To run quick build for Linux, you can run the following:  
 ```


### PR DESCRIPTION
### Pull Request (PR) Checklist
- [x] I have read the [CONTRIBUTING](./CONTRIBUTING.MD) doc
- [ ] PR is from **a topic/feature/bugfix branch** off the **dev branch** (right side)
- [ ] PR is against the **dev branch** (left side)
- [ ] Merlin compiles without errors
- [ ] Passes linting checks and unit tests
- [ ] Updated [CHANGELOG](./CHANGELOG.MD)
- [x] Updated README documentation (if applicable)
- [ ] Update Merlin version number in `pkg/merlin.go` (if applicable)

### Change Type
- [x] Addition
- [ ] Bugfix
- [ ] Modification
- [ ] Removal
- [ ] Security

### Description

Adding golang requirements for building against the most current commit (in main) of kubesploit. I recently tried to build this with the most recent version of go (using docker.io/golang ), but it failed every time I ran `make agent-linux`.  When I looked at the documentation for <https://github.com/traefik/yaegi/tree/v0.9.2#features> it says that it requires 1.13 or 1.14, so after pulling that down (docker.io/golang:1.14) it worked perfectly when I built kubesploit from source. 