### PR TITLE
Adding support to "root=PARTUUID" for MountBreakout module and scanner

### DIFF
--- a/data/modules/sourcecode/go/mountBreakout/main.go
+++ b/data/modules/sourcecode/go/mountBreakout/main.go
@@ -39,8 +39,10 @@ func extractDeviceType(deviceType string) (string,error) {
 
 			// extracting the UUID of the device
 			for _, splitLine := range splittedCmdLine {
-				if strings.HasPrefix(splitLine, "root=UUID") {
-					uuid = splitLine[10:]
+				if strings.HasPrefix(splitLine, "root=UUID") || strings.HasPrefix(splitLine, "root=PARTUUID") {
+					//uuid = splitLine[10:]
+					split2 := strings.Split(splitLine, "=")
+					uuid = split2[len(split2) - 1]
 					foundUUID = true
 				}
 			}

--- a/data/modules/sourcecode/go/vulnerabilityTest/main.go
+++ b/data/modules/sourcecode/go/vulnerabilityTest/main.go
@@ -214,8 +214,10 @@ func getRootFSDevice()(string, error){
 
 		// extracting the UUID of the device which hold the root file system
 		for _, splitLine := range splittedCmdLine {
-			if strings.HasPrefix(splitLine, "root=UUID") {
-				uuid = splitLine[10:]
+			if strings.HasPrefix(splitLine, "root=UUID") || strings.HasPrefix(splitLine, "root=PARTUUID")  {
+				//uuid = splitLine[10:]
+				split2 := strings.Split(splitLine, "=")
+                                uuid = split2[len(split2) - 1]
 				foundUUID = true
 				break
 			}


### PR DESCRIPTION
### Pull Request (PR) Checklist
- [x] I have read the [CONTRIBUTING](./CONTRIBUTING.MD) doc
- [ ] PR is from **a topic/feature/bugfix branch** off the **dev branch** (right side)
- [ ] PR is against the **dev branch** (left side)
- [ ] Merlin compiles without errors
- [ ] Passes linting checks and unit tests
- [ ] Updated [CHANGELOG](./CHANGELOG.MD)
- [ ] Updated README documentation (if applicable)
- [ ] Update Merlin version number in `pkg/merlin.go` (if applicable)

### Change Type
- [ ] Addition
- [x] Bugfix
- [ ] Modification
- [ ] Removal
- [ ] Security

### Description

This is a fix for issue #12 :
I noticed that when I run the vulnerabilityTest module on a privileged container, it wrote that it the container is not vulnerable to the mount attack while it was vulnerable.  
The problem was because in my machine the `/proc/cmdline` didn't have `root=UUID`, it had `root=PARTUUID`:  
```
BOOT_IMAGE=/boot/vmlinuz-5.11.0-1027-aws root=PARTUUID=5198cbc0-01 ro ...
```
In the code, we checked only the case where you have `root=UUID`:  
https://github.com/cyberark/kubesploit/blob/fb4471b2ff18662c706e676a7f24c33168eb9456/data/modules/sourcecode/go/vulnerabilityTest/main.go#L215-L221 

We need to fix it in the vulnerability test but also in the mountBreakoutModule:  
https://github.com/cyberark/kubesploit/blob/fb4471b2ff18662c706e676a7f24c33168eb9456/data/modules/sourcecode/go/mountBreakout/main.go#L41-L45  

Notice that the mountBreakoutModule will still work because the **default** technique doesn't use the cmdline.  